### PR TITLE
bug(mark-all-as-read): fix property name

### DIFF
--- a/router/notifications.js
+++ b/router/notifications.js
@@ -46,7 +46,7 @@ router.put('/mark-all-read', async (req, res) => {
 
   try {
     const [updatedCount] = await Notification.update(
-      { is_read: true },
+      { isRead: true },
       {
         where: {
           userId,


### PR DESCRIPTION
- change `is_read` to `isRead`
- closes https://trello.com/c/SXqfA64F/140-mark-all-as-read